### PR TITLE
Only use StructuredName contact data in StructuredName columns

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -565,7 +565,7 @@ public class ContactsManager extends ReactContextBaseJavaModule {
         ops.add(op.build());
 
         op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
-                .withSelection(ContactsContract.Data.CONTACT_ID + "=?", new String[]{String.valueOf(recordID)})
+                .withSelection(ContactsContract.Data.CONTACT_ID + "=? AND " + ContactsContract.Data.MIMETYPE + " = ?", new String[]{String.valueOf(recordID), StructuredName.CONTENT_ITEM_TYPE})
                 .withValue(ContactsContract.Data.MIMETYPE, StructuredName.CONTENT_ITEM_TYPE)
                 .withValue(StructuredName.GIVEN_NAME, givenName)
                 .withValue(StructuredName.MIDDLE_NAME, middleName)


### PR DESCRIPTION
This update operation currently replaces all rows in the `ContactsContract.Data` table for the given `CONTACT_ID` with `StructuredName` data. This replaces all data with mimetype `group_membership`, `note`, `contact_event`, `relation`, `contact_misc` with the contact's `StructuredName`. This PR adds the correct `where` clause to the `StructuredName` update operation so that only rows with `name` mimetype are updated with the `StructuredName` data.